### PR TITLE
Flip poloidal angle direction when iota<0

### DIFF
--- a/src/bzx/bzx.py
+++ b/src/bzx/bzx.py
@@ -1517,10 +1517,18 @@ def input_from_boozmn(fname_boozmn: str) -> 'Boozmn':
 
     #satake : flip poloidal angle direction if iota<0
     jdg_i = 0
+    jdg_i_pos = 0
 
     for js in range(boozmn.ns_b):
         if (boozmn.iota_b_nu[js]<0.0):
             jdg_i = 1
+        elif (boozmn.iota_b_nu[js]>0.0):
+            jdg_i_pos = 1
+
+    if (jdg_i == 1 and jdg_i_pos == 1):
+        raise ValueError(
+            'iota_b_nu changes sign across flux surfaces; '
+            'BZX assumes a globally consistent iota sign.')
 
     if (jdg_i == 1):
         print(' flip poloidal angle so that iota > 0')

--- a/src/bzx/bzx.py
+++ b/src/bzx/bzx.py
@@ -419,7 +419,8 @@ class Metric:
             self.rho[js] = js / numpy.abs(nrho - 1.0)       # Uniform rho grid
 
         for js in range(boozmn.ns_b):
-            self.qq_nu[js] = 1.0 / numpy.abs(boozmn.iota_b_nu[js])
+            # iota > 0 is ensured by the poloidal-angle flip in input_from_boozmn
+            self.qq_nu[js] = 1.0 / boozmn.iota_b_nu[js]
 
     def interpolation_to_uniform(self, nrho: int, boozmn: Boozmn):
         # --- interpolation to uniform rho-grids
@@ -1513,6 +1514,19 @@ def input_from_boozmn(fname_boozmn: str) -> 'Boozmn':
                 except:
                     raise RuntimeError('Read error8 !!')
     #%%%
+
+    #satake : flip poloidal angle direction if iota<0
+    jdg_i = 0
+
+    for js in range(boozmn.ns_b):
+        if (boozmn.iota_b_nu[js]<0.0):
+            jdg_i = 1
+
+    if (jdg_i == 1):
+        print(' flip poloidal angle so that iota > 0')
+        boozmn.iota_b_nu = -boozmn.iota_b_nu
+        boozmn.buco_b_nu = -boozmn.buco_b_nu
+        boozmn.ixm_b     = -boozmn.ixm_b
 
     return boozmn
 

--- a/tests/test_bzx.py
+++ b/tests/test_bzx.py
@@ -148,6 +148,21 @@ def test_negative_iota_flips_poloidal_angle(tmp_path):
     assert np.array_equal(boozmn.ixn_b, boozmn_ref.ixn_b)
 
 
+def test_mixed_sign_iota_is_rejected(tmp_path):
+    import xarray as xr
+
+    mixed_file = tmp_path / "boozmn_mixed_sign_iota.nc"
+    with xr.load_dataset(str(BOOZMN_FILE)) as ds:
+        iota = ds["iota_b"].copy()
+        iota_values = iota.to_numpy()
+        iota_values[1] = -abs(iota_values[1])
+        ds["iota_b"] = (iota.dims, iota_values)
+        ds.to_netcdf(str(mixed_file))
+
+    with pytest.raises(ValueError, match="changes sign"):
+        input_from_boozmn(str(mixed_file))
+
+
 def test_phi_interpolation_uses_full_mesh():
     boozmn, metric = _extrapolated_boozmn_and_metric()
     metric.q_profile(NTHETA_GKV, NRHO, NTHT, NZETA, boozmn)

--- a/tests/test_bzx.py
+++ b/tests/test_bzx.py
@@ -103,7 +103,7 @@ def test_q_profile_uses_half_mesh(generated_metric_file):
     boozmn, metric = _extrapolated_boozmn_and_metric()
     rho_half = _rho_half_from_jlist(boozmn)
     expected_qq, _ = _spline_all(
-        rho_half, 1.0 / np.abs(boozmn.iota_b_nu), rho,
+        rho_half, 1.0 / boozmn.iota_b_nu, rho,
         warn_out_of_bounds=False)
 
     assert rho_half[0] == 0.0
@@ -124,6 +124,28 @@ def test_fourier_coefficients_use_half_mesh(generated_metric_file):
         expected_bbozc, _ = _spline_all(
             rho_half, metric.bbozc_nu[imn, :], rho, warn_out_of_bounds=False)
         assert np.allclose(bbozc[imn, :], expected_bbozc, atol=1e-10, rtol=1e-10)
+
+
+def test_negative_iota_flips_poloidal_angle(tmp_path):
+    """An iota<0 equilibrium is converted to iota>0 by flipping the
+    poloidal angle direction (iota, buco, ixm sign flip), so that the
+    direction of increasing poloidal angle aligns with the field."""
+    import xarray as xr
+
+    flipped_file = tmp_path / "boozmn_negative_iota.nc"
+    with xr.load_dataset(str(BOOZMN_FILE)) as ds:
+        ds["iota_b"] = -ds["iota_b"]
+        ds["buco_b"] = -ds["buco_b"]
+        ds.to_netcdf(str(flipped_file))
+
+    boozmn_ref = input_from_boozmn(str(BOOZMN_FILE))
+    boozmn = input_from_boozmn(str(flipped_file))
+
+    assert np.all(boozmn.iota_b_nu[1:] > 0.0)
+    assert np.allclose(boozmn.iota_b_nu, boozmn_ref.iota_b_nu)
+    assert np.allclose(boozmn.buco_b_nu, boozmn_ref.buco_b_nu)
+    assert np.array_equal(boozmn.ixm_b, -boozmn_ref.ixm_b)
+    assert np.array_equal(boozmn.ixn_b, boozmn_ref.ixn_b)
 
 
 def test_phi_interpolation_uses_full_mesh():


### PR DESCRIPTION
## Summary

Handle equilibria with iota<0:

- `input_from_boozmn()`: if any flux surface has iota<0, flip the poloidal
  angle direction by negating `iota_b_nu`, `buco_b_nu` (covariant poloidal
  B component) and `ixm_b` (poloidal mode numbers; theta -> -theta is
  equivalent to m -> -m in the phase `m*theta - n*zeta`).
- `q_profile()`: since iota>0 is now guaranteed, the safety factor is
  computed as `q = 1/iota` instead of `q = 1/abs(iota)`.

The convention here is that the direction of increasing poloidal angle is
chosen to align with the magnetic field direction. In GKV's field-aligned
coordinates (z=theta), v_parallel>0 then always corresponds to increasing z,
which keeps upwind differencing and the parallel in/outflow boundary
conditions consistent. As a result, q is always positive and the Jacobian
of the flux-tube coordinates is always positive.

## Impact

- For iota>0 equilibria the output is bit-identical (the existing
  regression test against reference data passes unchanged).
- For iota<0 equilibria, `ixm_b` in the output metric file becomes
  negative. Confirmed safe for GKV: in `gkvp_vmecbzx.f90`, `ixm_bz` is
  read but never used afterward, and all quantities actually used by the
  solver (q, shat, eps, B, rootg, ggup, dB derivatives, ph) are computed
  in BZX after the flip. This convention has also been validated
  end-to-end with GKV in a linear benchmark.

## Tests

- Added `test_negative_iota_flips_poloidal_angle`: feeds a boozmn file
  with negated iota/buco and checks that iota>0 is restored and `ixm_b`
  is sign-flipped after reading.
- Updated `test_q_profile_uses_half_mesh` to the new `q = 1/iota`
  convention (equivalent for the iota>0 test fixture).
- All 5 tests pass.
